### PR TITLE
Pseudo class support

### DIFF
--- a/glue.py
+++ b/glue.py
@@ -246,6 +246,12 @@ class Image(object):
         self.name = name
         self.sprite = sprite
         self.filename, self.format = name.rsplit('.', 1)
+        self.pseudo = ''
+        
+        if self.filename.find('.') != -1:
+            self.filename, self.pseudo = self.filename.rsplit('.', 1)
+            self.pseudo = ":%s" % self.pseudo
+        
         image_path = os.path.join(sprite.path, name)
 
         image_file = open(image_path, "rb")
@@ -331,6 +337,7 @@ class Image(object):
         * ``animals/cow_20.png`` CSS class will be ``.sprite-animals-cow``
         """
         name = self.filename
+            
         if not self.sprite.manager.config.ignore_filename_paddings:
             padding_info_name = '-'.join(self._padding_info)
             if padding_info_name:
@@ -338,7 +345,7 @@ class Image(object):
             name = name[:len(padding_info_name) * -1 or None]
         name = re.sub(r'[^\w\-_]', '', name)
 
-        return '%s-%s' % (self.sprite.namespace, name)
+        return '%s-%s%s' % (self.sprite.namespace, name, self.pseudo)
 
     @property
     def _padding_info(self):


### PR DESCRIPTION
I have been using glue for a few weeks now and it has been awesome, thanks for writing it.  However, I needed :hover pseudo class for a project I am working on and got tired of manually having to reposition every time the sprite was recreated.  I have added some minimal pseudo class support where the pseudo class is defined in the file name with a '.{pseudo class}' before the '.{extension}'.  I hope you find this useful.
