### PR TITLE
Adding namespace to global-template

### DIFF
--- a/glue.py
+++ b/glue.py
@@ -629,7 +629,9 @@ class Sprite(object):
         # add the global style for all the sprites for less bloat
         template = self.config.global_template.decode('unicode-escape')
         css_file.write(template % {'all_classes': class_names,
-                                   'sprite_url': self.image_url})
+                                   'sprite_url': self.image_url,
+                                   'namespace': self.namespace,
+                                   })
 
         # compile one template for each file
         margin = int(self.config.margin)


### PR DESCRIPTION
Hi Jorge-

I use glue to compile to LESS files, and I'm using the global-template setting to create a variable that contains the path to the spritemap image. And it's actually a project, so I'm creating multiple spritemaps at once. I need each of these variables to have different names. Adding the namespace option to the global-template setting helps tremendously in streamlining my process.

Thanks,
-Sandy Weisz
