### PR TITLE
Fixed UnicodeError when using --global-template with UTF8 text

### DIFF
--- a/glue.py
+++ b/glue.py
@@ -9,6 +9,8 @@ import signal
 import StringIO
 import hashlib
 import subprocess
+import traceback
+import codecs
 import ConfigParser
 from optparse import OptionParser, OptionGroup
 
@@ -843,7 +845,8 @@ class Sprite(object):
         # Process the sprite if necessary.
         self.process()
 
-        css_file = open(css_filename, 'w')
+        # write css in UTF8-encoded file
+        css_file = codecs.open(css_filename, 'w', 'utf-8-sig')
 
         # Write the hash line to the file.
         css_file.write(hash_line)
@@ -853,7 +856,7 @@ class Sprite(object):
                                                   if ':' not in i.class_name])
 
         # add the global style for all the sprites for less bloat
-        template = self.config.global_template.decode('unicode-escape')
+        template = self.config.global_template.decode(sys.getfilesystemencoding())
         css_file.write(template % {'all_classes': class_names,
                                    'sprite_url': self.image_url()})
 
@@ -1526,6 +1529,7 @@ def main():
     except Exception:
         if config.debug:
             import platform
+            sys.stderr.write("Exception:\n%s\n" % traceback.format_exc())
             sys.stderr.write("Glue version: %s\n" % __version__)
             sys.stderr.write("PIL version: %s\n" % PImage.VERSION)
             sys.stderr.write("Platform: %s\n" % platform.platform())


### PR DESCRIPTION
Further changes:
- write CSS in an UTF-8 encoded file by using the "codecs" import
- show traceback of "Unknown Errors" when in debug mode

Description:
I encountered weird UnicodeEncode errors when using glue on command line on *nix systems. After enabling error tracebacks, I found out that handling of user specified global CSS templates containing UTF8 characters lacked a proper UTF8 decoding. Decoding was in place, but only using "unicode-escape". 

I have now fixed this issue by decoding user input by using the codec specified by `sys.getfilesystemencoding()` and by writing the output CSS file encoded as UTF8.

There might be some problems with this implementation as it is not tested on Windows machines, but this change fixed the issue I have been experiencing.
