### PR TITLE
Added variable "identifier" to --each-template

### DIFF
--- a/glue.py
+++ b/glue.py
@@ -870,6 +870,7 @@ class Sprite(object):
 
             template = self.config.each_template.decode('unicode-escape')
             css_file.write(template % {'class_name': '.%s' % image.class_name,
+                                       'identifier': image.class_name,
                                        'sprite_url': self.image_url(),
                                        'height': height,
                                        'width': width,


### PR DESCRIPTION
In some cases its necessary to adjust the x- and y-values for the background-positions of some sprites. Of example to center a sprite image which is used for bullet points.

With the variable "identifier" its possible to create @LessVariables for x- and y-values in each-template to use them in own Less files.
