### PR TITLE
Python header files are required to build modules

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,7 +24,7 @@ If you are using Debian/Ubuntu installing ``glue`` is really easy:
 
 .. code-block:: bash
 
-    $ apt-get install libjpeg62 libjpeg62-dev zlib1g-dev
+    $ apt-get install libjpeg62 libjpeg62-dev zlib1g-dev python-dev
     $ sudo pip install glue
 
 You can also install it using the native package:


### PR DESCRIPTION
Install fails with an error about a missing header file otherwise.
