### PR TITLE
Fix ImageMagick path problem on Windows.

### DIFF
--- a/glue.py
+++ b/glue.py
@@ -810,7 +810,7 @@ class Sprite(object):
                         data = {'path': sprite_image_path,
                                 'imagemagickpath': self.config.imagemagickpath,
                                 'ratio': (100.0 / self.max_ratio) * ratio}
-                        command = ["%(imagemagickpath)s %(path)s -resize %(ratio)s%% %(path)s" % data]
+                        command = ("%(imagemagickpath)s %(path)s -resize %(ratio)s%% %(path)s" % data).split(" ")
                         error = subprocess.call(command,
                                                 shell=True,
                                                 stdin=subprocess.PIPE,


### PR DESCRIPTION
If the parameters are not split, Glue cannot execute ImageMagick's convert command on the images with higher ratio on Windows.
