### PR TITLE
Provide access to width/height from within the GLOBAL_TEMPLATE string.

### DIFF
--- a/glue.py
+++ b/glue.py
@@ -883,8 +883,11 @@ class Sprite(object):
 
         # add the global style for all the sprites for less bloat
         template = self.config.global_template.decode('unicode-escape')
+        width, height = ['%spx' % int(s / self.max_ratio) for s in self.canvas_size]
         css_file.write(template % {'all_classes': class_names,
-                                   'sprite_url': self.image_url()})
+                                   'sprite_url': self.image_url(),
+                                   'width': width,
+                                   'height': height})
 
         # compile one template for each file
         margin = int(self.config.margin)


### PR DESCRIPTION
This is useful in a few cases, where I need to set the background dimensions explicitly.

Generally I think it's useful to provide all contextual variables to all templates, but this is a start.
