### PR TITLE
Use relative paths for image path hashing

### DIFF
--- a/glue.py
+++ b/glue.py
@@ -1013,7 +1013,7 @@ class Sprite(object):
         """
         hash_list = []
         for image in sorted(self.images, key=lambda i: i.path):
-            hash_list.append(image.path)
+            hash_list.append(os.path.relpath(image.path))
             hash_list.append(image._data)
 
         for key in DEFAULT_SETTINGS:


### PR DESCRIPTION
Use relative paths for hashing source image paths. This produces consistent hashes even in setups with multiple developers, building from a checkout in a tmp directory, etc.
