### PR TITLE
Fix #125. Update Pillow to require at least 2.2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     py_modules=['glue'],
     platforms='any',
     install_requires=[
-        'Pillow==1.7.8'
+        'Pillow>=2.2.2'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Pillow version < 2.2.2 won't build on Mac 10.9
