### PR TITLE
Add mixins for stylus.  Add in settings of "format_file" (remove "less")

### DIFF
--- a/glue.py
+++ b/glue.py
@@ -80,7 +80,6 @@ DEFAULT_SETTINGS = {
          '    if r in arg\n'
          '      width: %(width)s importance\n'
          '      height: %(height)s importance\n'
-         '      height: %(height)s importance\n'
          '  else\n'
          '    display: inline-block importance\n'
          '    background: url(%(sprite_url)s) no-repeat %(x)s %(y)s importance\n'


### PR DESCRIPTION
Usage.

Configuration files:
format_file=css (example: styl, less ...)
stylus_mixins=True (%name-mixins.styl)
stylus_mixins_template

Command line arguments:
--stylus - analogously "--css"
