### PR TITLE
Add cocos2d offset format

### DIFF
--- a/glue/core.py
+++ b/glue/core.py
@@ -45,6 +45,8 @@ class Image(ConfigurableFromFile):
 
         self.x = self.y = None
         self.original_width = self.original_height = 0
+        # Cocos2dx offset
+        self.offsetX = self.offsetY = 0
 
         with open(self.path, "rb") as img:
             self._image_data = img.read()
@@ -77,7 +79,10 @@ class Image(ConfigurableFromFile):
         # without losing any non-transparent pixel.
         # This crop is only used if the crop flag is set in the config.
         if self.config['crop']:
-            img = img.crop(img.split()[-1].getbbox())
+            croppedBox = img.split()[-1].getbbox()
+            img = img.crop(croppedBox)
+            self.offsetX = croppedBox[0] + (img.size[0]/2) - (self.original_width/2)
+            self.offsetY = (self.original_height/2) - croppedBox[1] - (img.size[1]/2)
         return img
 
     @property

--- a/glue/formats/base.py
+++ b/glue/formats/base.py
@@ -111,6 +111,10 @@ class BaseTextFormat(BaseFormat):
                                           y=round_up(base_y / self.sprite.max_ratio * r),
                                           abs_x=round_up(base_abs_x / self.sprite.max_ratio * r),
                                           abs_y=round_up(base_abs_y / self.sprite.max_ratio * r),
+                                          original_width=round_up(img.original_width / r),
+                                          original_height=round_up(img.original_height / r),
+                                          offsetX=round_up(img.offsetX / r),
+                                          offsetY=round_up(img.offsetY / r),
                                           height=round_up((img.height + img.padding[0] + img.padding[2]) / self.sprite.max_ratio * r),
                                           width=round_up((img.width + img.padding[1] + img.padding[3]) / self.sprite.max_ratio * r))
 

--- a/glue/formats/cocos2d.py
+++ b/glue/formats/cocos2d.py
@@ -34,12 +34,18 @@ class Cocos2dFormat(BasePlistFormat):
                              'textureFileName': ratio_context['sprite_filename']
                 }
         }
+
+        # frame: sprite location within the sprite-sheet as position and size values
+        # offset: difference between the original center of the sprite and the center of the cropped sprite
+        # rotated: whether or not the sprite has been rotated within the sprite-sheet
+        # sourceColorRect: rectangle with actual color information inside your source sprite
+        # sourceSize: size of the original sprite
         for i in context['images']:
             image_context = i['ratios'][ratio]
             rect = '{{{{{abs_x}, {abs_y}}}, {{{width}, {height}}}}}'.format(**image_context)
             data['frames'][i['filename']] = {'frame': rect,
-                                             'offset': '{0,0}',
+                                             'offset': '{{{offsetX},{offsetY}}}'.format(**image_context),
                                              'rotated': False,
                                              'sourceColorRect': rect,
-                                             'sourceSize': '{{{width}, {height}}}'.format(**image_context)}
+                                             'sourceSize': '{{{original_width}, {original_height}}}'.format(**image_context)}
         return data


### PR DESCRIPTION
In cocos2d images can be cropped in the sprites sheet but they keep their original size when using them in cocos2d. This feature is useful for animations. 

When cropped, sprite’s need to be offset to ensure their texture is drawn in correct alignment to their original size. This PR implement offset for the cocos2d format.

PS: An option might be added to glue to actually crop the image or keep its original size.
For instance TexturePacker implements the following options:
--trim-mode=None (images are not cropped at all)
--trim-mode=Trim (transparency is removed but original size is kept)
--trim-mode=Crop (sprite appears in the sheet as if it never had any transparency)
