### PR TITLE
reading sprite config with project level

### DIFF
--- a/glue/core.py
+++ b/glue/core.py
@@ -32,6 +32,11 @@ class ConfigurableFromFile(object):
             return {}
         return dict([[k, clean(config.get(section, k))] for k in keys])
 
+class ProjectConfig(ConfigurableFromFile):
+    def __init__(self,config_path):
+        self.config_path = config_path
+    def items(self):
+        return self._get_config_from_file('sprite.conf','sprite')
 
 class Image(ConfigurableFromFile):
 

--- a/glue/managers/project.py
+++ b/glue/managers/project.py
@@ -2,7 +2,7 @@ import os
 
 from glue.exceptions import NoSpritesFoldersFoundError
 from .base import BaseManager
-
+from glue.core import ProjectConfig
 
 class ProjectManager(BaseManager):
     """Process a path searching for folders that contain images.
@@ -11,6 +11,8 @@ class ProjectManager(BaseManager):
        the ``--project`` argument."""
 
     def find_sprites(self):
+
+        self.config.update( ProjectConfig(self.config['source']).items() )
 
         for filename in sorted(os.listdir(self.config['source'])):
 


### PR DESCRIPTION
Add 'Project-level' configuration support.

http://glue.readthedocs.org/en/latest/files.html#introduction

```
sprites
    ├── actions
    │   ├── add.png
    │   ├── remove.png
    │   └── sprite.conf
    └── icons
    │   ├── comment.png
    │   ├── new.png
    │   └── rss.png
    └── sprite.conf
```

The arguments in the sprite-level configuration file can overwrite the value of 'sprite.conf' in the project folder.

The glue DO NOT read the arguments in the 'Project-level' file after v0.9 and that's different with v0.3 before.

So I add this future back to the latest version.
