### PR TITLE
Remove duplicate word from the usage message

### DIFF
--- a/glue/bin.py
+++ b/glue/bin.py
@@ -16,7 +16,7 @@ def main(argv=None):
 
     argv = (argv or sys.argv)[1:]
 
-    parser = argparse.ArgumentParser(usage=("usage: %(prog)s [source | --source | -s] [output | --output | -o]"))
+    parser = argparse.ArgumentParser(usage=("%(prog)s [source | --source | -s] [output | --output | -o]"))
 
     parser.add_argument("--source", "-s",
                         dest="source",


### PR DESCRIPTION
argparse add 'usage: '

before:

``` csh
$ glue -h
usage: usage: glue [source | --source | -s] [output | --output | -o]
```

after:

``` csh
$ glue -h
usage: glue [source | --source | -s] [output | --output | -o]
```
