### PR TITLE
brew should not install packages using sudo

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ Before installing ``Homebrew`` you'll need to install Xcode, then you can follow
 
 .. code-block:: bash
 
-    $ sudo brew install jpeg
+    $ brew install jpeg
     $ sudo pip install glue
 
 .. note::


### PR DESCRIPTION
Error: Cowardly refusing to `sudo brew install`
You can use brew with sudo, but only if the brew executable is owned by root.
However, this is both not recommended and completely unsupported so do so at
your own risk.
