### PR TITLE
fix issue #161 -- remove utf-8-sig for utf-8 for output files

### DIFF
--- a/glue/formats/base.py
+++ b/glue/formats/base.py
@@ -136,7 +136,7 @@ class BaseTextFormat(BaseFormat):
         if not os.path.exists(self.output_dir(*args, **kwargs)):
             os.makedirs(self.output_dir(*args, **kwargs))
 
-        with codecs.open(self.output_path(*args, **kwargs), 'w', 'utf-8-sig') as f:
+        with codecs.open(self.output_path(*args, **kwargs), 'w', 'utf-8') as f:
             f.write(self.render(*args, **kwargs))
 
 
@@ -148,7 +148,7 @@ class BaseJSONFormat(BaseTextFormat):
         for ratio in self.sprite.config['ratios']:
             json_path = self.output_path(ratio)
             if os.path.exists(json_path):
-                with codecs.open(json_path, 'r', 'utf-8-sig') as f:
+                with codecs.open(json_path, 'r', 'utf-8') as f:
                     try:
                         data = json.loads(f.read())
                         assert data[self.meta_key]['hash'] == self.sprite.hash

--- a/glue/formats/css.py
+++ b/glue/formats/css.py
@@ -131,7 +131,7 @@ class CssFormat(JinjaTextFormat):
     def needs_rebuild(self):
         hash_line = '/* glue: %s hash: %s */\n' % (__version__, self.sprite.hash)
         try:
-            with codecs.open(self.output_path(), 'r', 'utf-8-sig') as existing_css:
+            with codecs.open(self.output_path(), 'r', 'utf-8') as existing_css:
                 first_line = existing_css.readline()
                 assert first_line == hash_line
         except Exception:

--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -1,6 +1,5 @@
 import os
 import json
-import codecs
 
 from base import BaseJSONFormat
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires=[
 ]
 
 tests_require=[
-    'cssutils>=0.9,<1.0',
+    'cssutils>=0.9.10,<1.0',
 ]
 
 # as of Python >= 2.7 argparse module is maintained within Python.


### PR DESCRIPTION
also noticed that the tests don't work with cssutils before ~0.9.10 because the
validate kw was not added to parseFile until at least after 0.9.8a3

tests all pass