### PR TITLE
test locally with tox, add explicit classifiers for python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 .DS_Store
 tests_tmp
 *.egg
+*.tox

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,11 @@ setup(
     test_suite='tests',
     classifiers=[
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+# Tox (http://codespeak.net/~hpk/tox/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py33, py34
+
+[testenv]
+commands = python setup.py test


### PR DESCRIPTION
so that https://caniusepython3.com/ can declare that this project supports python 3

Do what you want with this pull request, it is not actually necessary to be that precise in the classifiers.
