### PR TITLE
Fix incorrect order in JSON output

### DIFF
--- a/glue/formats/base.py
+++ b/glue/formats/base.py
@@ -158,7 +158,7 @@ class BaseJSONFormat(BaseTextFormat):
         return False
 
     def render(self, *args, **kwargs):
-        return json.dumps(self.get_context(*args, **kwargs))
+        return json.dumps(self.get_context(*args, **kwargs), indent=4)
 
 
 class BasePlistFormat(BaseTextFormat):

--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import os
 import json
 import codecs
@@ -33,7 +34,7 @@ class JSONFormat(BaseJSONFormat):
     def get_context(self, *args, **kwargs):
         context = super(JSONFormat, self).get_context(*args, **kwargs)
 
-        frames = dict([[i['filename'], {'filename': i['filename'],
+        frames = OrderedDict([[i['filename'], {'filename': i['filename'],
                                         'frame': {'x': i['x'],
                                                   'y': i['y'],
                                                   'w': i['width'],
@@ -47,7 +48,7 @@ class JSONFormat(BaseJSONFormat):
                                         'sourceSize': {'w': i['original_width'],
                                                        'h': i['original_height']}}] for i in context['images']])
 
-        data = dict(frames=None, meta={'version': context['version'],
+        data = OrderedDict(frames=None, meta={'version': context['version'],
                                        'hash': context['hash'],
                                        'name': context['name'],
                                        'sprite_path': context['sprite_path'],


### PR DESCRIPTION
I found out that dict.values() and json.dumps() will break the current order of dict.
I tried to use OrderedDict instead of dict and the issue was resolved.