### PR TITLE
Add output_abs_xy option

### DIFF
--- a/glue/formats/base.py
+++ b/glue/formats/base.py
@@ -158,7 +158,7 @@ class BaseJSONFormat(BaseTextFormat):
         return False
 
     def render(self, *args, **kwargs):
-        return json.dumps(self.get_context(*args, **kwargs))
+        return json.dumps(self.get_context(*args, **kwargs), indent=4)
 
 
 class BasePlistFormat(BaseTextFormat):

--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -31,18 +31,27 @@ class JSONFormat(BaseJSONFormat):
                            choices=['array', 'hash'],
                            help=("JSON structure format (array, hash)"))
 
+        group.add_argument("--output_abs_xy",
+                           dest="output_abs_xy",
+                           nargs='?',
+                           const=True,
+                           default=os.environ.get('GLUE_JSON', False),
+                           metavar='DIR',
+                           help="Output x,y as positive values")
+
     def get_context(self, *args, **kwargs):
         context = super(JSONFormat, self).get_context(*args, **kwargs)
 
+        output_abs_xy = self.sprite.config.get('output_abs_xy')
         frames = OrderedDict([[i['filename'], {'filename': i['filename'],
-                                        'frame': {'x': i['x'],
-                                                  'y': i['y'],
+                                        'frame': {'x': i['abs_x'] if output_abs_xy else i['x'],
+                                                  'y': i['abs_y'] if output_abs_xy else i['y'],
                                                   'w': i['width'],
                                                   'h': i['height']},
                                         'rotated': False,
                                         'trimmed': False,
-                                        'spriteSourceSize': {'x': i['x'],
-                                                             'y': i['y'],
+                                        'spriteSourceSize': {'x': i['abs_x'] if output_abs_xy else i['x'],
+                                                             'y': i['abs_y'] if output_abs_xy else i['y'],
                                                              'w': i['width'],
                                                              'h': i['height']},
                                         'sourceSize': {'w': i['original_width'],

--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import os
 import json
 import codecs
@@ -33,7 +34,7 @@ class JSONFormat(BaseJSONFormat):
     def get_context(self, *args, **kwargs):
         context = super(JSONFormat, self).get_context(*args, **kwargs)
 
-        frames = dict([[i['filename'], {'filename': i['filename'],
+        frames = OrderedDict([[i['filename'], {'filename': i['filename'],
                                         'frame': {'x': i['x'],
                                                   'y': i['y'],
                                                   'w': i['width'],
@@ -47,7 +48,7 @@ class JSONFormat(BaseJSONFormat):
                                         'sourceSize': {'w': i['original_width'],
                                                        'h': i['original_height']}}] for i in context['images']])
 
-        data = dict(frames=None, meta={'version': context['version'],
+        data = OrderedDict(frames=None, meta={'version': context['version'],
                                        'hash': context['hash'],
                                        'name': context['name'],
                                        'sprite_path': context['sprite_path'],


### PR DESCRIPTION
I don't know why we have to output x,y as nagative values. But my engine uses top-left coordinate system, so  positive x,y are more easier for parsing metadata.

I only added this option to JSON format because I'm not sure other formats need it.