### PR TITLE
added a Phaser.js compatible JSON output format

### DIFF
--- a/glue/formats/__init__.py
+++ b/glue/formats/__init__.py
@@ -4,9 +4,9 @@ from .img import ImageFormat
 from .html import HtmlFormat
 from .jsonformat import JSONFormat
 from .caat import CAATFormat
+from .phaser import PhaserFormat
 from .less import LessFormat
 from .scss import ScssFormat
-
 
 formats = {'css': CssFormat,
            'cocos2d': Cocos2dFormat,
@@ -14,5 +14,6 @@ formats = {'css': CssFormat,
            'html': HtmlFormat,
            'json': JSONFormat,
            'caat': CAATFormat,
+           'phaser': PhaserFormat,
            'less': LessFormat,
            'scss': ScssFormat}

--- a/glue/formats/phaser.py
+++ b/glue/formats/phaser.py
@@ -1,0 +1,61 @@
+import os
+
+from base import BaseJSONFormat
+
+
+class PhaserFormat(BaseJSONFormat):
+
+    extension = 'json'
+    build_per_ratio = True
+
+    @classmethod
+    def populate_argument_parser(cls, parser):
+        group = parser.add_argument_group("JSON format options")
+
+        group.add_argument("--phaser",
+                           dest="phaser_dir",
+                           nargs='?',
+                           const=True,
+                           default=os.environ.get('GLUE_PHASER', False),
+                           metavar='DIR',
+                           help="Generate phaser compatible files and optionally where")
+
+    def get_context(self, *args, **kwargs):
+        context = super(PhaserFormat, self).get_context(*args, **kwargs)
+        if kwargs['ratio']:
+            use_context = context['ratios'][kwargs['ratio']]
+            width = use_context['width']
+            height = use_context['height']
+        else:
+            width = context['width']
+            height = context['height']
+
+        data = dict(frames={}, meta={
+            'app': 'https://github.com/jorgebastida/glue/',
+            'version': context['version'],
+            'format': 'RGBA8888',
+            'image': context['sprite_filename'],
+            'size': {
+                'w': width,
+                'h': height
+                },
+            'scale': 1
+        })
+
+
+        for i in context['images']:
+            if 'ratio' in kwargs:
+                image_dict = i['ratios'][kwargs['ratio']]
+            else:
+                image_dict = i
+
+            data['frames'][i['filename']] = {
+                'frame': {
+                    'x' : image_dict['abs_x'],
+                    'y' : image_dict['abs_y'],
+                    'w' : image_dict['width'],
+                    'h' : image_dict['height']
+                }
+            }
+
+        return data

--- a/tests.py
+++ b/tests.py
@@ -1814,7 +1814,7 @@ class TestGlue(unittest.TestCase):
             data = json.loads(f.read())
             self.assertEqual(data['meta'], {
                 u'app': u'https://github.com/jorgebastida/glue/',
-                u'version': unicode(__version__),
+                u'version': __version__,
                 u'format': u'RGBA8888',
                 u'image': u'simple.png',
                 u'size': {
@@ -1859,7 +1859,7 @@ class TestGlue(unittest.TestCase):
 
             self.assertEqual(data['meta'], {
                 u'app': u'https://github.com/jorgebastida/glue/',
-                u'version': unicode(__version__),
+                u'version': __version__,
                 u'format': u'RGBA8888',
                 u'image': u'simple.png',
                 u'size': {
@@ -1893,7 +1893,7 @@ class TestGlue(unittest.TestCase):
 
             self.assertEqual(data['meta'], {
                 u'app': u'https://github.com/jorgebastida/glue/',
-                u'version': unicode(__version__),
+                u'version': __version__,
                 u'format': u'RGBA8888',
                 u'image': u'simple.png',
                 u'size': {

--- a/tests.py
+++ b/tests.py
@@ -24,6 +24,7 @@ except ImportError:
 from glue.bin import main
 from glue.core import Image
 from glue.helpers import redirect_stdout
+from glue import __version__
 
 
 RED = (255, 0, 0, 255)
@@ -1800,6 +1801,126 @@ class TestGlue(unittest.TestCase):
         with codecs.open('output/simple@2x.json', 'r', 'utf-8-sig') as f:
             data = json.loads(f.read())
             assert isinstance(data['sprites'], dict)
+
+    def test_phaser(self):
+        self.create_image("simple/red.png", RED, size=(64,64))
+        self.create_image("simple/blue.png", BLUE, size=(64,64))
+        code = self.call("glue simple output --phaser")
+        self.assertEqual(code, 0)
+
+        self.assertExists("output/simple.png")
+        self.assertExists("output/simple.json")
+        with codecs.open('output/simple.json', 'r', 'utf-8-sig') as f:
+            data = json.loads(f.read())
+            self.assertEqual(data['meta'], {
+                u'app': u'https://github.com/jorgebastida/glue/',
+                u'version': unicode(__version__),
+                u'format': u'RGBA8888',
+                u'image': u'simple.png',
+                u'size': {
+                    u'w': 128,
+                    u'h': 64
+                },
+                u'scale': 1
+            })
+
+            self.assertEqual(data['frames'], {
+                u'red.png': {
+                    u'frame': {
+                        u'x': 0,
+                        u'y': 0,
+                        u'w': 64,
+                        u'h': 64
+                    }
+                },
+                u'blue.png': {
+                    u'frame': {
+                        u'x': 64,
+                        u'y': 0,
+                        u'w': 64,
+                        u'h': 64
+                    }
+                }
+            })
+
+    def test_phaser_ratios(self):
+        self.create_image("simple/red.png", RED, size=(64,64))
+        self.create_image("simple/blue.png", BLUE, size=(64,64))
+        code = self.call("glue simple output --phaser --retina")
+        self.assertEqual(code, 0)
+
+        self.assertExists("output/simple.png")
+        self.assertExists("output/simple.json")
+        self.assertExists("output/simple@2x.png")
+        self.assertExists("output/simple@2x.json")
+
+        with codecs.open('output/simple.json', 'r', 'utf-8-sig') as f:
+            data = json.loads(f.read())
+
+            self.assertEqual(data['meta'], {
+                u'app': u'https://github.com/jorgebastida/glue/',
+                u'version': unicode(__version__),
+                u'format': u'RGBA8888',
+                u'image': u'simple.png',
+                u'size': {
+                    u'w': 64,
+                    u'h': 32
+                },
+                u'scale': 1
+            })
+
+            self.assertEqual(data['frames'], {
+                u'red.png': {
+                    u'frame': {
+                        u'x': 0,
+                        u'y': 0,
+                        u'w': 32,
+                        u'h': 32
+                    }
+                },
+                u'blue.png': {
+                    u'frame': {
+                        u'x': 32,
+                        u'y': 0,
+                        u'w': 32,
+                        u'h': 32
+                    }
+                }
+            })
+
+        with codecs.open('output/simple@2x.json', 'r', 'utf-8-sig') as f:
+            data = json.loads(f.read())
+
+            self.assertEqual(data['meta'], {
+                u'app': u'https://github.com/jorgebastida/glue/',
+                u'version': unicode(__version__),
+                u'format': u'RGBA8888',
+                u'image': u'simple.png',
+                u'size': {
+                    u'w': 128,
+                    u'h': 64
+                },
+                u'scale': 1
+            })
+
+            self.assertEqual(data['frames'], {
+                u'red.png': {
+                    u'frame': {
+                        u'x': 0,
+                        u'y': 0,
+                        u'w': 64,
+                        u'h': 64
+                    }
+                },
+                u'blue.png': {
+                    u'frame': {
+                        u'x': 64,
+                        u'y': 0,
+                        u'w': 64,
+                        u'h': 64
+                    }
+                }
+            })
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit adds a JSON format which allows the resulting sprite to be loaded into Phaser using the [game.load.atlasJSONHash](http://phaser.io/docs/2.3.0/Phaser.Loader.html#atlasJSONHash) function. The format is loosely based on the one created by [Texture Packer](https://www.codeandweb.com/texturepacker) but slimmed down - the Texture Packer format includes loads of flags in the JSON even if they're false and therefore redundant.
