### PR TITLE
Accept newer versions of Jinja2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 install_requires=[
     'Pillow>=2.2.2',
-    'Jinja2>=2.7,<2.8',
+    'Jinja2>=2.7',
 ]
 
 tests_require=[


### PR DESCRIPTION
I've tested glue with Jinja2 2.8 and it works perfectly. Both with unittests and manual testing generating a sprite from the famfam icon set.

Jinja2 2.8 was released almost a year ago and most recent Linux distributions use it by default.
