### PR TITLE
Feature/json meta image

### DIFF
--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -57,7 +57,8 @@ class JSONFormat(BaseJSONFormat):
                                        'sprite_path': context['sprite_path'],
                                        'sprite_filename': context['sprite_filename'],
                                        'width': context['width'],
-                                       'height': context['height']})
+                                       'height': context['height']
+                                       'image': context['sprite_filename']})
 
         if self.sprite.config['json_format'] == 'array':
             data['frames'] = frames.values()

--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -57,7 +57,7 @@ class JSONFormat(BaseJSONFormat):
                                        'sprite_path': context['sprite_path'],
                                        'sprite_filename': context['sprite_filename'],
                                        'width': context['width'],
-                                       'height': context['height']
+                                       'height': context['height'],
                                        'image': context['sprite_filename']})
 
         if self.sprite.config['json_format'] == 'array':


### PR DESCRIPTION
Hi,
I am new to making pull requests, but thought I'd give it a try.  The reason that I am sending this PR is because I wanted to use the Glue repo to make sprite sheets for use with the pixi.js loader that expects a json format from TexturePacker.  I found that if I set the GLUE_JSON_FORMAT='hash', I still need a meta key named "image" for the filename value.  So, I simply added this key to the meta dictionary in the jsonformat.py file in the formats.