### PR TITLE
Feature/json format txtpkr

### DIFF
--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -62,16 +62,17 @@ class JSONFormat(BaseJSONFormat):
 
         if self.sprite.config['json_format'] == 'array':
             data['frames'] = frames.values()
-        else:
+        elif self.sprite.config['json_format'] == 'hash':
             data['frames'] = frames
-            if self.sprite.config['json_format'] == 'txtpkr':
-                for d in data['frames']:
-                    x = int(d['frame']['x'])
-                    y = int(d['frame']['y'])
-                    # Make the x,y coordinates grow in positive numbers
-                    d['frame']['x'] = x*-1
-                    d['frame']['y'] = y*-1
-                    d['spriteSourceSize']['x'] = x*-1
-                    d['spriteSourceSize']['y'] = y*-1
+        else: 
+            for k,v in frames:
+                x = frames[k]['frame']['x']
+                y = frames[k]['frame']['y']
+                # Make the x,y coordinates grow in positive numbers
+                frames[k]['frame']['x'] = x*-1
+                frames[k]['frame']['y'] = y*-1
+                frames[k]['spriteSourceSize']['x'] = x*-1
+                frames[k]['spriteSourceSize']['y'] = y*-1
+            data['frames'] = frames
 
         return data

--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -31,8 +31,8 @@ class JSONFormat(BaseJSONFormat):
                            metavar='NAME',
                            type=unicode,
                            default=os.environ.get('GLUE_JSON_FORMAT', 'array'),
-                           choices=['array', 'hash'],
-                           help=("JSON structure format (array, hash)"))
+                           choices=['array', 'hash','txtpkr'],
+                           help=("JSON structure format (array, hash, txtpkr)"))
 
     def get_context(self, *args, **kwargs):
         context = super(JSONFormat, self).get_context(*args, **kwargs)
@@ -64,5 +64,14 @@ class JSONFormat(BaseJSONFormat):
             data['frames'] = frames.values()
         else:
             data['frames'] = frames
+            if self.sprite.config['json_format'] == 'txtpkr':
+                for d in data['frames']:
+                    x = d['frame']['x']
+                    y = d['frame']['y']
+                    # Make the x,y coordinates grow in positive numbers
+                    d['frame']['x'] = x*-1
+                    d['frame']['y'] = y*-1
+                    d['spriteSourceSize']['x'] = x*-1
+                    d['spriteSourceSize']['y'] = y*-1
 
         return data

--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -57,7 +57,8 @@ class JSONFormat(BaseJSONFormat):
                                        'sprite_path': context['sprite_path'],
                                        'sprite_filename': context['sprite_filename'],
                                        'width': context['width'],
-                                       'height': context['height']})
+                                       'height': context['height']
+                                       'image': context['sprite_filename']})
 
         if self.sprite.config['json_format'] == 'array':
             data['frames'] = frames.values()

--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -57,7 +57,7 @@ class JSONFormat(BaseJSONFormat):
                                        'sprite_path': context['sprite_path'],
                                        'sprite_filename': context['sprite_filename'],
                                        'width': context['width'],
-                                       'height': context['height']
+                                       'height': context['height'],
                                        'image': context['sprite_filename']})
 
         if self.sprite.config['json_format'] == 'array':

--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -66,8 +66,8 @@ class JSONFormat(BaseJSONFormat):
             data['frames'] = frames
             if self.sprite.config['json_format'] == 'txtpkr':
                 for d in data['frames']:
-                    x = d['frame']['x']
-                    y = d['frame']['y']
+                    x = int(d['frame']['x'])
+                    y = int(d['frame']['y'])
                     # Make the x,y coordinates grow in positive numbers
                     d['frame']['x'] = x*-1
                     d['frame']['y'] = y*-1

--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -65,7 +65,7 @@ class JSONFormat(BaseJSONFormat):
         elif self.sprite.config['json_format'] == 'hash':
             data['frames'] = frames
         else: 
-            for k,v in frames:
+            for k,v in frames.items():
                 x = frames[k]['frame']['x']
                 y = frames[k]['frame']['y']
                 # Make the x,y coordinates grow in positive numbers


### PR DESCRIPTION
I created the option 'txtpkr' for the json format.  This resulting sprite sheet now works with the pixi.js loader that expects the sprite sheet to be generated via Texture Packer.  The details include changing the x,y coordinates to grow in positive numbers.  The details also include the key 'image' key in the meta data (see earlier PR).