### PR TITLE
Unicode filename support fixing #203

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "3.4"
   - "3.3"
   - "2.7"
-  - "2.6"
 install:
   - sudo apt-get install zlib1g-dev
   - sudo ln -s /usr/lib/i386-linux-gnu/libz.so /usr/lib

--- a/glue/bin.py
+++ b/glue/bin.py
@@ -154,12 +154,12 @@ def main(argv=None):
     extra = 0
     # Get the source from the source option or the first positional argument
     if not options.source and args:
-        options.source = args[0]
+        options.source = unicode(args[0])
         extra += 1
 
     # Get the output from the output option or the second positional argument
     if not options.output and args[extra:]:
-        options.output = args[extra]
+        options.output = unicode(args[extra])
 
     # Check if source is available
     if options.source is None:

--- a/glue/formats/css.py
+++ b/glue/formats/css.py
@@ -182,7 +182,7 @@ class CssFormat(JinjaTextFormat):
     def generate_css_name(self, filename):
         filename = filename.rsplit('.', 1)[0]
         separator = self.sprite.config['css_separator']
-        namespace = [re.sub(r'[^\w\-_]', '', filename)]
+        namespace = [re.sub(r'[^\w\-_]', '', filename, flags=re.UNICODE)]
 
         # Add sprite namespace if required
         if self.sprite.config['css_sprite_namespace']:

--- a/glue/managers/watch.py
+++ b/glue/managers/watch.py
@@ -3,6 +3,7 @@ import sys
 import time
 import signal
 import hashlib
+import unicodedata
 
 
 class WatchManager(object):
@@ -29,6 +30,7 @@ class WatchManager(object):
         hash_list = []
         for root, dirs, files in os.walk(self.options['source']):
             for f in sorted([f for f in files if not f.startswith('.')]):
+                f = unicodedata.normalize('NFC', f)
                 hash_list.append(os.path.join(root, f))
                 hash_list.append(str(os.path.getmtime(os.path.join(root, f))))
         hash_list = ''.join(hash_list)

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import sys
 import json
@@ -199,6 +200,31 @@ class TestGlue(unittest.TestCase):
                         u'height': u'64px'})
 
         self.assertCSS(u"output/simple.css", u'.sprite-simple-blue',
+                       {u'background-image': u"url(simple.png)",
+                        u'background-repeat': u'no-repeat',
+                        u'background-position': u'-64px 0',
+                        u'width': u'64px',
+                        u'height': u'64px'})
+
+    def test_unicode_input_output(self):
+        self.create_image(u"simple/redöåä.png", RED)
+        self.create_image(u"simple/blueöåä.png", BLUE)
+        code = self.call("glue simple output")
+        self.assertEqual(code, 0)
+
+        self.assertExists("output/simple.png")
+        self.assertExists("output/simple.css")
+        self.assertColor("output/simple.png", RED, ((0, 0), (63, 63)))
+        self.assertColor("output/simple.png", BLUE, ((64, 0), (127, 63)))
+
+        self.assertCSS(u"output/simple.css", u'.sprite-simple-redöåä',
+                       {u'background-image': u"url(simple.png)",
+                        u'background-repeat': u'no-repeat',
+                        u'background-position': u'0 0',
+                        u'width': u'64px',
+                        u'height': u'64px'})
+
+        self.assertCSS(u"output/simple.css", u'.sprite-simple-blueöåä',
                        {u'background-image': u"url(simple.png)",
                         u'background-repeat': u'no-repeat',
                         u'background-position': u'-64px 0',
@@ -1800,6 +1826,7 @@ class TestGlue(unittest.TestCase):
         with codecs.open('output/simple@2x.json', 'r', 'utf-8-sig') as f:
             data = json.loads(f.read())
             assert isinstance(data['sprites'], dict)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Non-ascii files raise errors, see #203 . On Mac it's more complex because the unicode filenames we read with `os.walk()` contain different codepoints for the same unicode characters we wrote (https://stackoverflow.com/a/33647372/193886 pointed me in the right direction, `unicodedata.normalize()` is your friend).
