### PR TITLE
chore: update for modern python versions (>=3.9)

### DIFF
--- a/glue/algorithms/__init__.py
+++ b/glue/algorithms/__init__.py
@@ -1,9 +1,9 @@
-from diagonal import DiagonalAlgorithm
-from horizontal import HorizontalAlgorithm
-from horizontal_bottom import HorizontalBottomAlgorithm
-from square import SquareAlgorithm
-from vertical import VerticalAlgorithm
-from vertical_right import VerticalRightAlgorithm
+from .diagonal import DiagonalAlgorithm
+from .horizontal import HorizontalAlgorithm
+from .horizontal_bottom import HorizontalBottomAlgorithm
+from .square import SquareAlgorithm
+from .vertical import VerticalAlgorithm
+from .vertical_right import VerticalRightAlgorithm
 
 algorithms = {'diagonal': DiagonalAlgorithm,
               'horizontal': HorizontalAlgorithm,

--- a/glue/bin.py
+++ b/glue/bin.py
@@ -3,6 +3,7 @@ import os
 import sys
 import argparse
 
+from PIL import __version__ as PILVersion
 from PIL import Image as PImage
 
 from glue.formats import formats
@@ -20,13 +21,13 @@ def main(argv=None):
 
     parser.add_argument("--source", "-s",
                         dest="source",
-                        type=unicode,
+                        type=str,
                         default=os.environ.get('GLUE_SOURCE', None),
                         help="Source path")
 
     parser.add_argument("--output", "-o",
                         dest="output",
-                        type=unicode,
+                        type=str,
                         default=os.environ.get('GLUE_OUTPUT', None),
                         help="Output path")
 
@@ -80,7 +81,7 @@ def main(argv=None):
     group.add_argument("-a", "--algorithm",
                        dest="algorithm",
                        metavar='NAME',
-                       type=unicode,
+                       type=str,
                        default=os.environ.get('GLUE_ALGORITHM', 'square'),
                        choices=['square', 'vertical', 'horizontal',
                                 'vertical-right', 'horizontal-bottom',
@@ -92,7 +93,7 @@ def main(argv=None):
     group.add_argument("--ordering",
                        dest="algorithm_ordering",
                        metavar='NAME',
-                       type=unicode,
+                       type=str,
                        default=os.environ.get('GLUE_ORDERING', 'maxside'),
                        choices=['maxside', 'width', 'height', 'area', 'filename',
                                 '-maxside', '-width', '-height', '-area', '-filename'],
@@ -100,7 +101,7 @@ def main(argv=None):
                              "filename (default: maxside)"))
 
     # Populate the parser with options required by other formats
-    for format in formats.itervalues():
+    for format in formats.values():
         format.populate_argument_parser(parser)
 
     #
@@ -146,7 +147,7 @@ def main(argv=None):
         options.enabled_formats.remove('img')
 
     # Fail if any of the deprecated arguments is used
-    for argument in deprecated_arguments.iterkeys():
+    for argument in deprecated_arguments.keys():
         if getattr(options, argument, None):
             parser.error(("{0} argument is deprectated "
                           "since v0.3").format(deprecated_arguments[argument]))
@@ -233,16 +234,16 @@ def main(argv=None):
                 manager.process()
         else:
             manager.process()
-    except exceptions.ValidationError, e:
+    except exceptions.ValidationError as e:
         sys.stderr.write(e.args[0])
         return e.error_code
-    except exceptions.SourceImagesNotFoundError, e:
+    except exceptions.SourceImagesNotFoundError as e:
         sys.stderr.write("Error: No images found in %s.\n" % e.args[0])
         return e.error_code
-    except exceptions.NoSpritesFoldersFoundError, e:
+    except exceptions.NoSpritesFoldersFoundError as e:
         sys.stderr.write("Error: No sprites folders found in %s.\n" % e.args[0])
         return e.error_code
-    except exceptions.PILUnavailableError, e:
+    except exceptions.PILUnavailableError as e:
         sys.stderr.write(("Error: PIL {0} decoder is unavailable"
                           "Please read the documentation and "
                           "install it before spriting this kind of "
@@ -259,13 +260,15 @@ def main(argv=None):
         sys.stderr.write("\n")
         sys.stderr.write("Version: {0}\n".format(__version__))
         sys.stderr.write("Python: {0}\n".format(sys.version))
-        sys.stderr.write("PIL version: {0}\n".format(PImage.VERSION))
+        sys.stderr.write("PIL version: {0}\n".format(PILVersion))
         sys.stderr.write("Platform: {0}\n".format(platform.platform()))
         sys.stderr.write("Config: {0}\n".format(vars(options)))
         sys.stderr.write("Args: {0}\n\n".format(sys.argv))
         sys.stderr.write(traceback.format_exc())
         sys.stderr.write("=" * 80)
         sys.stderr.write("\n")
+        import pdb
+        pdb.post_mortem(sys.exc_info()[-1])
         return 1
 
     return 0

--- a/glue/core.py
+++ b/glue/core.py
@@ -3,8 +3,8 @@ import os
 import sys
 import copy
 import hashlib
-import StringIO
-import ConfigParser
+from io import StringIO, BytesIO
+import configparser as ConfigParser
 
 from PIL import Image as PILImage
 
@@ -48,16 +48,16 @@ class Image(ConfigurableFromFile):
         with open(self.path, "rb") as img:
             self._image_data = img.read()
 
-        print "\t{0} added to sprite".format(self.filename)
+        print("\t{0} added to sprite".format(self.filename))
 
     @cached_property
     def image(self):
         """Return a Pil representation of this image """
 
         if sys.version < '3':
-            imageio = StringIO.StringIO(self._image_data)
+            imageio = StringIO(self._image_data)
         else:
-            imageio = StringIO.BytesIO(self._image_data)
+            imageio = BytesIO(self._image_data)
 
         try:
             source_image = PILImage.open(imageio)
@@ -70,7 +70,7 @@ class Image(ConfigurableFromFile):
                 img.paste(source_image, (0, 0), mask=mask)
             else:
                 img.paste(source_image, (0, 0))
-        except IOError, e:
+        except IOError as e:
             raise PILUnavailableError(e.args[0].split()[1])
         finally:
             imageio.close()
@@ -119,7 +119,7 @@ class Image(ConfigurableFromFile):
         else:
             data = [0] * 4
 
-        return map(int, data)
+        return list(map(int, data))
 
     @cached_property
     def horizontal_spacing(self):
@@ -196,7 +196,7 @@ class Sprite(ConfigurableFromFile):
             if ratio_output_key not in self.config:
                 self.config[ratio_output_key] = img_format.output_path(ratio)
 
-        print "Processing '{0}':".format(self.name)
+        print("Processing '{0}':".format(self.name))
 
         # Generate sprite map
         self.process()
@@ -220,7 +220,7 @@ class Sprite(ConfigurableFromFile):
             hash_list.append(os.path.relpath(image.path))
             hash_list.append(image._image_data)
 
-        for key, value in self.config.iteritems():
+        for key, value in self.config.items():
             hash_list.append(key)
             hash_list.append(value)
 

--- a/glue/formats/base.py
+++ b/glue/formats/base.py
@@ -54,7 +54,7 @@ class BaseFormat(object):
     @property
     def format_label(self):
         from glue.formats import formats
-        return dict((v,k) for k, v in formats.iteritems())[self.__class__]
+        return dict((v,k) for k, v in formats.items())[self.__class__]
 
     @classmethod
     def populate_argument_parser(cls, parser):

--- a/glue/formats/caat.py
+++ b/glue/formats/caat.py
@@ -1,6 +1,6 @@
 import os
 
-from base import BaseJSONFormat
+from .base import BaseJSONFormat
 
 
 class CAATFormat(BaseJSONFormat):

--- a/glue/formats/cocos2d.py
+++ b/glue/formats/cocos2d.py
@@ -1,6 +1,6 @@
 import os
 
-from base import BasePlistFormat
+from .base import BasePlistFormat
 
 
 class Cocos2dFormat(BasePlistFormat):

--- a/glue/formats/css.py
+++ b/glue/formats/css.py
@@ -3,7 +3,7 @@ import os
 import codecs
 
 from glue import __version__
-from base import JinjaTextFormat
+from .base import JinjaTextFormat
 
 from ..exceptions import ValidationError
 
@@ -54,20 +54,20 @@ class CssFormat(JinjaTextFormat):
 
         group.add_argument("--namespace",
                            dest="css_namespace",
-                           type=unicode,
+                           type=str,
                            default=os.environ.get('GLUE_CSS_NAMESPACE', 'sprite'),
                            help="Namespace for all css classes (default: sprite)")
 
         group.add_argument("--sprite-namespace",
                            dest="css_sprite_namespace",
-                           type=unicode,
+                           type=str,
                            default=os.environ.get('GLUE_CSS_SPRITE_NAMESPACE',
                                                   '{sprite_name}'),
                            help="Namespace for all sprites (default: {sprite_name})")
 
         group.add_argument("-u", "--url",
                            dest="css_url",
-                           type=unicode,
+                           type=str,
                            default=os.environ.get('GLUE_CSS_URL', ''),
                            help="Prepend this string to the sprites path")
 
@@ -94,7 +94,7 @@ class CssFormat(JinjaTextFormat):
 
         group.add_argument("--separator",
                            dest="css_separator",
-                           type=unicode,
+                           type=str,
                            default=os.environ.get('GLUE_CSS_SEPARATOR', '-'),
                            metavar='SEPARATOR',
                            help=("Customize the separator used to join CSS class "
@@ -103,7 +103,7 @@ class CssFormat(JinjaTextFormat):
 
         group.add_argument("--pseudo-class-separator",
                            dest="css_pseudo_class_separator",
-                           type=unicode,
+                           type=str,
                            default=os.environ.get('GLUE_CSS_PSEUDO_CLASS_SEPARATOR', '__'),
                            metavar='SEPARATOR',
                            help=("Customize the separator glue will use in order "
@@ -163,7 +163,7 @@ class CssFormat(JinjaTextFormat):
         if self.sprite.config['css_url']:
             context['sprite_path'] = '{0}{1}'.format(self.sprite.config['css_url'], context['sprite_filename'])
 
-            for r, ratio in context['ratios'].iteritems():
+            for r, ratio in context['ratios'].items():
                 ratio['sprite_path'] = '{0}{1}'.format(self.sprite.config['css_url'], ratio['sprite_filename'])
 
         # Add cachebuster if required
@@ -174,7 +174,7 @@ class CssFormat(JinjaTextFormat):
 
             context['sprite_path'] = apply_cachebuster(context['sprite_path'])
 
-            for r, ratio in context['ratios'].iteritems():
+            for r, ratio in context['ratios'].items():
                 ratio['sprite_path'] = apply_cachebuster(ratio['sprite_path'])
 
         return context

--- a/glue/formats/img.py
+++ b/glue/formats/img.py
@@ -19,7 +19,7 @@ class ImageFormat(BaseFormat):
 
         group.add_argument("--img",
                            dest="img_dir",
-                           type=unicode,
+                           type=str,
                            default=os.environ.get('GLUE_IMG', True),
                            metavar='DIR',
                            help="Output directory for img files")
@@ -38,13 +38,13 @@ class ImageFormat(BaseFormat):
 
         group.add_argument("-p", "--padding",
                            dest="padding",
-                           type=unicode,
+                           type=str,
                            default=os.environ.get('GLUE_PADDING', '0'),
                            help="Force this padding in all images")
 
         group.add_argument("--margin",
                            dest="margin",
-                           type=unicode,
+                           type=str,
                            default=os.environ.get('GLUE_MARGIN', '0'),
                            help="Force this margin in all images")
 
@@ -57,7 +57,7 @@ class ImageFormat(BaseFormat):
 
         group.add_argument("--ratios",
                            dest="ratios",
-                           type=unicode,
+                           type=str,
                            default=os.environ.get('GLUE_RATIOS', '1'),
                            help="Create sprites based on these ratios")
 

--- a/glue/formats/jsonformat.py
+++ b/glue/formats/jsonformat.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
-from base import BaseJSONFormat
+from .base import BaseJSONFormat
 
 
 class JSONFormat(BaseJSONFormat):
@@ -29,7 +29,7 @@ class JSONFormat(BaseJSONFormat):
         group.add_argument("--json-format",
                            dest="json_format",
                            metavar='NAME',
-                           type=unicode,
+                           type=str,
                            default=os.environ.get('GLUE_JSON_FORMAT', 'array'),
                            choices=['array', 'hash'],
                            help=("JSON structure format (array, hash)"))

--- a/glue/formats/less.py
+++ b/glue/formats/less.py
@@ -1,6 +1,6 @@
 import os
 
-from css import CssFormat
+from .css import CssFormat
 
 
 class LessFormat(CssFormat):

--- a/glue/formats/scss.py
+++ b/glue/formats/scss.py
@@ -1,6 +1,6 @@
 import os
 
-from css import CssFormat
+from .css import CssFormat
 
 
 class ScssFormat(CssFormat):

--- a/glue/helpers.py
+++ b/glue/helpers.py
@@ -1,7 +1,12 @@
 import os
 import sys
 import contextlib
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+
 
 
 def round_up(value):

--- a/glue/managers/base.py
+++ b/glue/managers/base.py
@@ -41,7 +41,7 @@ class BaseManager(object):
                 format = format_cls(sprite=sprite)
                 format.validate()
                 if format.needs_rebuild() or sprite.config['force']:
-                    print "Format '{0}' for sprite '{1}' needs rebuild...".format(format_name, sprite.name)
+                    print("Format '{0}' for sprite '{1}' needs rebuild...".format(format_name, sprite.name))
                     format.build()
                 else:
-                    print "Format '{0}'' for sprite '{1}' already exists...".format(format_name, sprite.name)
+                    print("Format '{0}'' for sprite '{1}' already exists...".format(format_name, sprite.name))

--- a/glue/managers/watch.py
+++ b/glue/managers/watch.py
@@ -39,5 +39,5 @@ class WatchManager(object):
 
     def signal_handler(self, signal, frame):
         """ Gracefully close the app if Ctrl+C is pressed."""
-        print 'You pressed Ctrl+C!'
+        print('You pressed Ctrl+C!')
         sys.exit(0)

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,4 @@ setup(
         ]
     },
     zip_safe = False,
-    use_2to3=True
 )


### PR DESCRIPTION
changes for py3 support
 - s/unicode/str
 - s/map/list(map
 - s/iterkeys/itervalues/iteritems -> keys(), values(), items()
 - s/print/print()

- remove use_2to3 option which is no longer valid

```
❯ pip install glue
Collecting glue                                                                                                                                                                            
  Using cached glue-0.13.tar.gz (295 kB) 
  Preparing metadata (setup.py) ... error                                                                                                                                                  
  error: subprocess-exited-with-error                                                                                                                                                      
                                                                                             
  × python setup.py egg_info did not run successfully.                                       
  │ exit code: 1
  ╰─> [1 lines of output]
      error in glue setup command: use_2to3 is invalid.                                                                                                                                    
      [end of output]                                                                        
                                                                                             
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed                                                            
```                                                           
